### PR TITLE
✨ Feature: #60 스테이지 사이 중간 스토리 전개 UI 및 로직 구현

### DIFF
--- a/NLP/NLP/Sources/App/CoordinatorPath.swift
+++ b/NLP/NLP/Sources/App/CoordinatorPath.swift
@@ -5,7 +5,7 @@
 //  Created by Ted on 7/14/25.
 //
 
-enum CoordinatorPath {
+enum CoordinatorPath: Hashable {
     /// 게임 실행 시 "이어서 진행" 또는 "처음부터 시작하기" 를 선택 가능한 화면입니다.
     case startGameScene
     /// 2045년, 인류는 스스로 신이라.... 의 멘트가 나오는 게임 첫 시작 시 세계관 설명이 진행되는 화면입니다.
@@ -16,4 +16,7 @@ enum CoordinatorPath {
     case stageOneScene
     /// Stage1 클리어 시 넘어가는 Stage2 화면입니다.
     case stageTwoScene
+    
+    /// Stage 넘어가는 사이의 스토리 전개 화면입니다.
+    case middleStoryScene(StoriesType)
 }

--- a/NLP/NLP/Sources/Presentation/RootScene/RootView.swift
+++ b/NLP/NLP/Sources/Presentation/RootScene/RootView.swift
@@ -43,6 +43,11 @@ struct RootView: View {
                             dialogManager: dialogManager
                         )
                             .toolbar(.hidden, for: .navigationBar)
+                    case .middleStoryScene(let storiesType):
+                        MiddleStoryView(
+                            coordinator: coordinator,
+                            storiesType: storiesType
+                        )
                     }
                 }
         }

--- a/NLP/NLP/Sources/Presentation/RootScene/RootView.swift
+++ b/NLP/NLP/Sources/Presentation/RootScene/RootView.swift
@@ -38,7 +38,10 @@ struct RootView: View {
                         )
                             .toolbar(.hidden, for: .navigationBar)
                     case .stageTwoScene:
-                        EmptyView()
+                        StageTwoView(
+                            coordinator: coordinator,
+                            dialogManager: dialogManager
+                        )
                             .toolbar(.hidden, for: .navigationBar)
                     }
                 }

--- a/NLP/NLP/Sources/Presentation/StageOneTwoMiddleStoryScene/MiddleStoryViewModel.swift
+++ b/NLP/NLP/Sources/Presentation/StageOneTwoMiddleStoryScene/MiddleStoryViewModel.swift
@@ -1,0 +1,60 @@
+//
+//  StageOneTwoMiddleStoryViewModel.swift
+//  NLP
+//
+//  Created by Ted on 7/18/25.
+//
+
+import SwiftUI
+
+final class MiddleStoryViewModel: ViewModelable {
+    struct State {
+        var isTransitioning: Bool = false
+        var storiesType: StoriesType
+        var storyIndex: Int = 0
+    }
+    
+    enum Action {
+        case goToNextStory
+    }
+    
+    @Published var state: State
+    @ObservedObject var coordinator: Coordinator
+    
+    init(
+        coordinator: Coordinator,
+        storiesType: StoriesType
+    ) {
+        self.coordinator = coordinator
+        self.state = State(storiesType: storiesType)
+    }
+    
+    func action(_ action: Action) {
+        switch action {
+        case .goToNextStory:
+            // 뒤에 스토리가 더 있다면
+            if state.storyIndex < state.storiesType.stories.count - 1 {
+                state.storyIndex += 1
+                return
+            }
+            
+            Task {
+                await MainActor.run {
+                    withAnimation(.linear(duration: 1)) {
+                        state.isTransitioning = true
+                    }
+                }
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                
+                // 스토리의 마지막이라면
+                switch state.storiesType {
+                case .stageOneTwo:
+                    coordinator.push(.stageTwoScene)
+                case .stageTwoThree:
+                    // 임의
+                    coordinator.push(.stageTwoScene)
+                }
+            }
+        }
+    }
+}

--- a/NLP/NLP/Sources/Presentation/StageOneTwoMiddleStoryScene/StageOneTwoMiddleStoryView.swift
+++ b/NLP/NLP/Sources/Presentation/StageOneTwoMiddleStoryScene/StageOneTwoMiddleStoryView.swift
@@ -1,0 +1,79 @@
+//
+//  StageOneTwoMiddleStoryView.swift
+//  NLP
+//
+//  Created by Ted on 7/18/25.
+//
+
+import SwiftUI
+
+struct MiddleStoryView: View {
+    @StateObject var viewModel: MiddleStoryViewModel
+    
+    init(
+        coordinator: Coordinator,
+        storiesType: StoriesType
+    ) {
+        _viewModel = StateObject(wrappedValue: MiddleStoryViewModel(
+            coordinator: coordinator,
+            storiesType: storiesType
+        ))
+    }
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Spacer()
+            }
+            let stories = viewModel.state.storiesType.stories
+            
+            Spacer().frame(height: 60)
+            
+            if let image = stories[viewModel.state.storyIndex].storyImage {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 270, height: 208)
+            } else {
+                Rectangle()
+                    .fill(.white)
+                    .frame(width: 270, height: 208)
+            }
+            Spacer().frame(height: 20)
+            Text(stories[viewModel.state.storyIndex].storyTitle)
+                .font(NLPFont.headline)
+                .padding(.bottom, 30)
+                .padding(.horizontal, 24)
+            Text(stories[viewModel.state.storyIndex].storyDescription)
+                .font(NLPFont.body)
+                .padding(.horizontal, 24)
+            Spacer()
+            GameButton(buttonText: "다음") {
+                viewModel.action(.goToNextStory)
+            }
+            .padding(.bottom, 40)
+            .padding(.horizontal, 24)
+        }
+        .ignoresSafeArea()
+        .background(Color.gray)
+        .overlay(
+            Color.black
+                .opacity(viewModel.state.isTransitioning ? 1 : 0)
+        )
+    }
+}
+
+/// 각 스테이지 넘어가는 위치에 따라 스토리 끝나고 실행시킬 게임 스테이지가 달라지므로, MiddleStoryView에 StoriesType을 넘기도록 구현
+enum StoriesType {
+    case stageOneTwo
+    case stageTwoThree
+    
+    var stories: [GameStory] {
+        switch self {
+        case .stageOneTwo:
+            return ConstantMiddleStories.stageOneTwo
+        case .stageTwoThree:
+            return ConstantMiddleStories.stageTwoThree
+        }
+    }
+}

--- a/NLP/NLP/Sources/Presentation/StageTwoScene/StageTwoView.swift
+++ b/NLP/NLP/Sources/Presentation/StageTwoScene/StageTwoView.swift
@@ -61,10 +61,16 @@ struct StageTwoView: View {
                 }
             }
         }
+        .overlay(
+            Color.black
+                .opacity(viewModel.state.isTransitioning ? 1 : 0)
+        )
         .allowsHitTesting(!viewModel.state.isTouchDisabled)
         .onAppear {
             initScene()
             dialogManager.initConversation(dialogPartner: .robot)
+            
+            viewModel.action(.transitionComplete)
         }
     }
     

--- a/NLP/NLP/Sources/Presentation/StageTwoScene/StageTwoViewModel.swift
+++ b/NLP/NLP/Sources/Presentation/StageTwoScene/StageTwoViewModel.swift
@@ -7,8 +7,10 @@
 
 import SwiftUI
 
+@MainActor
 final class StageTwoViewModel: ViewModelable {
     struct State {
+        var isTransitioning: Bool = true
         var isMonologuePresented: Bool = false
         var isItemCollecting: Bool = false
         var isDialogPresented: Bool = false
@@ -18,6 +20,7 @@ final class StageTwoViewModel: ViewModelable {
     }
     
     enum Action {
+        case transitionComplete
         case robotEncountered
         case activateDialog(withNextPhase: Bool)
         case activateMonologue(withNextPhase: Bool)
@@ -39,6 +42,11 @@ final class StageTwoViewModel: ViewModelable {
     
     func action(_ action: Action) {
         switch action {
+        case .transitionComplete:
+            withAnimation(.linear(duration: 1)) {
+                state.isTransitioning = false
+            }
+            
         case .robotEncountered:
             state.isMonologuePresented = true
         case .activateDialog(let withNextPhase):

--- a/NLP/NLP/Sources/Utils/Constants/ConstantMiddleStory.swift
+++ b/NLP/NLP/Sources/Utils/Constants/ConstantMiddleStory.swift
@@ -1,0 +1,50 @@
+//
+//  ConstantMiddleStory.swift
+//  NLP
+//
+//  Created by Ted on 7/18/25.
+//
+import SwiftUI
+
+struct ConstantMiddleStories {
+    static let stageOneTwo: [GameStory] = [
+        GameStory(
+            storyTitle: "키리던스 현상",
+            storyDescription:
+                """
+                그곳엔 우주개발을 위해 비밀리에 탑재한 신원소 키리듐(Keyridium) 이 저장되어 있었다. 키리듐은 상온 초전도체로서 막대한 에너지를 가질 뿐 아니라, 플라즈마와 반응 시 시간의 비대칭성을 유발할 수 있다. \n\n충돌로 인해 발생한 에너지 충격은 단순한 폭발이 아니었다. 중력 왜곡과 함께, 시간 자체의 흐름이 엉키는 ‘키리던스(Keyridance)’ 현상을 낳았다. \n\n시간은 루프가 아닌, 깨진 유리처럼 갈라진 채로 병렬로 존재한다. “우리는 다시 돌아가는 것이 아니다. 다른 선택으로 새로운 현실을 부여하는 것 뿐이다.”
+                """
+        ),
+        GameStory(
+            storyTitle: "이상한 로봇",
+            storyDescription:
+                """
+                그곳엔 우주개발을 위해 비밀리에 탑재한 신원소 키리듐(Keyridium) 이 저장되어 있었다. 키리듐은 상온 초전도체로서 막대한 에너지를 가질 뿐 아니라, 플라즈마와 반응 시 시간의 비대칭성을 유발할 수 있다. \n\n충돌로 인해 발생한 에너지 충격은 단순한 폭발이 아니었다. 중력 왜곡과 함께, 시간 자체의 흐름이 엉키는 ‘키리던스(Keyridance)’ 현상을 낳았다. \n\n시간은 루프가 아닌, 깨진 유리처럼 갈라진 채로 병렬로 존재한다. “우리는 다시 돌아가는 것이 아니다. 다른 선택으로 새로운 현실을 부여하는 것 뿐이다.”
+                """
+        )
+    ]
+    
+    static let stageTwoThree: [GameStory] = [
+        // MARK: 임시
+        GameStory(
+            storyTitle: "키리던스 현상",
+            storyDescription:
+                """
+                그곳엔 우주개발을 위해 비밀리에 탑재한 신원소 키리듐(Keyridium) 이 저장되어 있었다. 키리듐은 상온 초전도체로서 막대한 에너지를 가질 뿐 아니라, 플라즈마와 반응 시 시간의 비대칭성을 유발할 수 있다. \n\n충돌로 인해 발생한 에너지 충격은 단순한 폭발이 아니었다. 중력 왜곡과 함께, 시간 자체의 흐름이 엉키는 ‘키리던스(Keyridance)’ 현상을 낳았다. \n\n시간은 루프가 아닌, 깨진 유리처럼 갈라진 채로 병렬로 존재한다. “우리는 다시 돌아가는 것이 아니다. 다른 선택으로 새로운 현실을 부여하는 것 뿐이다.”
+                """
+        ),
+        GameStory(
+            storyTitle: "이상한 로봇",
+            storyDescription:
+                """
+                그곳엔 우주개발을 위해 비밀리에 탑재한 신원소 키리듐(Keyridium) 이 저장되어 있었다. 키리듐은 상온 초전도체로서 막대한 에너지를 가질 뿐 아니라, 플라즈마와 반응 시 시간의 비대칭성을 유발할 수 있다. \n\n충돌로 인해 발생한 에너지 충격은 단순한 폭발이 아니었다. 중력 왜곡과 함께, 시간 자체의 흐름이 엉키는 ‘키리던스(Keyridance)’ 현상을 낳았다. \n\n시간은 루프가 아닌, 깨진 유리처럼 갈라진 채로 병렬로 존재한다. “우리는 다시 돌아가는 것이 아니다. 다른 선택으로 새로운 현실을 부여하는 것 뿐이다.”
+                """
+        )
+    ]
+}
+
+struct GameStory {
+    var storyImage: UIImage?
+    var storyTitle: String
+    var storyDescription: String
+}


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #60

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 스테이지 사이 중간 스토리 전개 UI 및 로직을 구현하였습니다.

---

### 📸 스크린샷 


https://github.com/user-attachments/assets/ef5c2436-60dc-4ab0-9583-7e020353e581



---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16 pro, iOS 26.0 환경에서 정상 동작

---

### 💬 기타 공유 사항

- Stage1에서 2로 넘어갈 때의 스토리인지, 2에서 3로 넘어갈 때의 스토리인지를 알기 위한 StoriesType을 coordinatorPath 의 연관값으로 주도록 구현하였습니다.