### PR TITLE
🐛 Bug: #95 DialogManager의 initializeSesison 메서드에서 UnlockTool로만 tool 설정하고 있던 부분 인자로 넘어온 tools로 설정하도록 수정

### DIFF
--- a/NLP/NLP/Sources/Dialog/DialogManager.swift
+++ b/NLP/NLP/Sources/Dialog/DialogManager.swift
@@ -38,14 +38,7 @@ class DialogManager: ObservableObject {
     ) {
         let newSession: LanguageModelSession = LanguageModelSession(
             model: .default,
-            tools: [
-                UnlockTool(rightPasswordAction: { [weak self] in
-                // MARK: computer instruction 변경(기획에 따라 추가 예정) 및 세션 초기화
-                self?.initializeSession(
-                    dialogPartner: dialogPartner,
-                    instructions: instructions, tools: tools // TODO: 미결정
-                )
-            })],
+            tools: tools,
             instructions: instructions
         )
         newSession.prewarm()


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #95

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- DialogManager의 initializeSesison 메서드에서 UnlockTool로만 tool 설정하고 있던 부분 인자로 넘어온 tools로 설정하도록 수정

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26.0 환경에서 정상 동작
