### PR TITLE
Fix: Stage 3 SignalMachine과 Monologue 겹쳐서 출력되는 문제 해결

### DIFF
--- a/NLP/NLP/Sources/Common/DesignSystem/SignalMachineDetailView.swift
+++ b/NLP/NLP/Sources/Common/DesignSystem/SignalMachineDetailView.swift
@@ -26,11 +26,17 @@ struct SignalMachineDetailView: View {
                 
                 HStack {
                     Spacer()
-                    Button(action: {
+                    Button(isClickSoundAvailable: true, action: {
+                        if !skip {
+                            skip.toggle()
+                            return
+                        }
+                        
                         if let action = action[phase] {
                             action()
                         }
-                        phase = phase.nextPhase ?? .lastPhase
+                        guard let nextPhase = phase.nextPhase else { return }
+                        phase = nextPhase
                     }) {
                         Text("다음 >")
                             .font(NLPFont.body)
@@ -48,6 +54,9 @@ struct SignalMachineDetailView: View {
             .frame(width: ConstantScreenSize.screenWidth, height: ConstantScreenSize.screenHeight*0.35)
         }
         .ignoresSafeArea()
+        .onAppear {
+            skip = false
+        }
     }
 }
 

--- a/NLP/NLP/Sources/Presentation/StageThreeScene/StageThreeView.swift
+++ b/NLP/NLP/Sources/Presentation/StageThreeScene/StageThreeView.swift
@@ -168,7 +168,7 @@ struct StageThreeView: View {
                     monologue: "다음",
                     action: {
                         viewModel.action(.deactivateMonologue)
-                        scene.moveToSignalMachine()
+                        scene.changePositionPlayerToSignalMachine()
                         viewModel.action(.goToNextPhase)
                     }
                 )

--- a/NLP/NLP/Sources/Presentation/StageThreeScene/StageThreeViewModel.swift
+++ b/NLP/NLP/Sources/Presentation/StageThreeScene/StageThreeViewModel.swift
@@ -54,17 +54,21 @@ final class StageThreeViewModel: ViewModelable {
             }
         case .activateDialog(let withNextPhase):
             state.isMonologuePresented = false
+            state.isSignalMachinePresented = false
             state.isDialogPresented = true
             if withNextPhase {
                 state.stageThreePhase = state.stageThreePhase.nextPhase ?? .lastPhase
             }
         case .activateMonologue(let withNextPhase):
             state.isDialogPresented = false
+            state.isSignalMachinePresented = false
             state.isMonologuePresented = true
             if withNextPhase {
                 state.stageThreePhase = state.stageThreePhase.nextPhase ?? .lastPhase
             }
         case .activateSignalMachine(let withNextPhase):
+            state.isDialogPresented = false
+            state.isMonologuePresented = false
             state.isSignalMachinePresented = true
             if withNextPhase {
                 state.signalMachinePhase = state.signalMachinePhase.nextPhase ?? .lastPhase


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #163 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- Stage 3 SignalMachine과 Monologue 겹쳐서 출력되는 문제 해결

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26.0 환경에서 정상 동작

---