### PR TITLE
Fix: 첫번째 StreamingText skip 동작 무시되는 에러 해결

### DIFF
--- a/NLP/NLP/Sources/Common/DesignSystem/StreamingText.swift
+++ b/NLP/NLP/Sources/Common/DesignSystem/StreamingText.swift
@@ -79,6 +79,7 @@ struct StreamingText: View {
         }
         .font(NLPFont.body)
         .onAppear {
+            skip = false
             startTimer()
         }
         .onChange(of: fullAttributedText) { _, _ in


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #188 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- StreamingText .onAppear에 skip = false 추가.
- 첫번째 StreamingText skip 동작 무시되는 에러 해결

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26.0 환경에서 정상 동작

---