### PR TITLE
✨ Featture, Fix: Stage 1 산소 없음 Game Over 구현

### DIFF
--- a/NLP/NLP/Sources/App/Coordinator.swift
+++ b/NLP/NLP/Sources/App/Coordinator.swift
@@ -23,6 +23,10 @@ class Coordinator: ObservableObject {
         paths.removeAll()
     }
     
+    func popAllAndPush(_ path: CoordinatorPath) {
+        paths = [path]
+    }
+    
     func popToRoot() {
         let root = paths.first
         guard let root = root else { return }

--- a/NLP/NLP/Sources/App/CoordinatorPath.swift
+++ b/NLP/NLP/Sources/App/CoordinatorPath.swift
@@ -22,6 +22,9 @@ enum CoordinatorPath: Hashable {
     /// Stage 넘어가는 사이의 스토리 전개 화면입니다.
     case middleStoryScene(StoriesType)
     
+    // Game Over 화면입니다.
+    case gameOverScene
+    
     /// Ending, Credit 화면입니다.
     case endingCreditScene
 }

--- a/NLP/NLP/Sources/Presentation/GameOverScene/GameOverView.swift
+++ b/NLP/NLP/Sources/Presentation/GameOverScene/GameOverView.swift
@@ -1,0 +1,45 @@
+//
+//  GameOverView.swift
+//  NLP
+//
+//  Created by 양시준 on 7/31/25.
+//
+
+import SwiftUI
+
+struct GameOverView: View {
+    @State var isTransitioning: Bool = true
+    @State var isGameOverShown: Bool = false
+    
+    @ObservedObject var coordinator: Coordinator
+    
+    init(coordinator: Coordinator) {
+        self.coordinator = coordinator
+    }
+    
+    var body: some View {
+        ZStack {
+            Image("StartGameImage")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+            
+            Text("Game Over")
+                .font(NLPFont.headline)
+                .foregroundStyle(NLPColor.label)
+                .opacity(isGameOverShown ? 1 : 0)
+                .animation(.linear(duration: 1), value: isGameOverShown)
+        }
+        .ignoresSafeArea()
+        .background(.blue)
+        .onAppear {
+            isTransitioning = false
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                isGameOverShown = true
+            }
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 9) {
+                coordinator.popAllAndPush(.startGameScene)
+            }
+        }
+    }
+}

--- a/NLP/NLP/Sources/Presentation/RootScene/RootView.swift
+++ b/NLP/NLP/Sources/Presentation/RootScene/RootView.swift
@@ -65,12 +65,14 @@ struct RootView: View {
                             dialogManager: dialogManager
                         )
                             .toolbar(.hidden, for: .navigationBar)
-                        
-                    case .endingCreditScene:
-                        EndingCreditView(coordinator: coordinator)
-                            .toolbar(.hidden, for: .navigationBar)
                     case .stageFourScene:
                         StageFourGameView(coordinator: coordinator)
+                            .toolbar(.hidden, for: .navigationBar)
+                    case .gameOverScene:
+                        GameOverView(coordinator: coordinator)
+                            .toolbar(.hidden, for: .navigationBar)
+                    case .endingCreditScene:
+                        EndingCreditView(coordinator: coordinator)
                             .toolbar(.hidden, for: .navigationBar)
                     }
                 }

--- a/NLP/NLP/Sources/Presentation/StageOneGameScene/StageOneGameView.swift
+++ b/NLP/NLP/Sources/Presentation/StageOneGameScene/StageOneGameView.swift
@@ -184,6 +184,9 @@ help 명령어를 치던 그 시절이 떠오른다. 아무것도 모르는 언�
                         withAnimation(.linear(duration: 1)) {
                             viewModel.state.isTransitioning = true
                         }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            viewModel.coordinator.popAllAndPush(.gameOverScene)
+                        }
                     }
                     Spacer()
                 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #224 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- GameOverView 추가
- CoordinatorPath에 .gameOverScene 추가
- Coordinator에 popAllAndPush(_ path: CoordinatorPath) 추가
- Stage 1에서 산소 없어지면 GameOverView로 넘어갔다가 첫화면으로 이동 구현.

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


https://github.com/user-attachments/assets/81adad3e-d0d2-414a-bd63-35c4e0328a1a


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26.0 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- coordinator에 popAll() 한 후 바로 push를 호출하면 애니메이션이 겹쳐 예측 불가능한 문제가 발생했습니다. Coordinator에 popAllAndPush 메서드를 만들어 사용하여 해결했습니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- StageOneGameView의 `if viewModel.state.isOxygenDecreasingStarted && !isDoorOpened { }`